### PR TITLE
Fixes for building with ifx

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ fpm test --compiler gfortran --profile release
 Compiler bugs related to generic name resolution currently prevent `ifx` from building Fiats versions 0.15.0 or later.
 Test and build earlier versions of Fiats build with the following command:
 ```
-fpm test --compiler ifx --profile release --flag -O3
+fpm test --compiler ifx --flag -fpp --profile release
 ```
 
 ##### _Experimental:_ Automatic offloading of `do concurrent` to GPUs

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ fpm test --compiler gfortran --profile release
 ```
 
 ##### Intel (`ifx`)
-Compiler bugs related to generic name resolution currently prevent `ifx` from building Fiats versions 0.15.0 or later.
+Compiler bugs related to generic name resolution currently prevent `ifx` from building Fiats versions 0.15.0 or later. An upcoming release in 2025 is expected to fix these bugs.
 Test and build earlier versions of Fiats build with the following command:
 ```
 fpm test --compiler ifx --flag -fpp --profile release

--- a/src/fiats/neural_network_m.f90
+++ b/src/fiats/neural_network_m.f90
@@ -21,7 +21,7 @@ module neural_network_m
   type neural_network_t(k)
     !! Encapsulate the information needed to perform inference
     integer, kind :: k = default_real 
-    type(tensor_map_t(k)), private :: input_map_, output_map_
+    type(tensor_map_t(k)) :: input_map_, output_map_
     type(metadata_t), private :: metadata_
     real(k), allocatable, private :: weights_(:,:,:), biases_(:,:)
     integer, allocatable, private :: nodes_(:)

--- a/src/fiats/neural_network_s.F90
+++ b/src/fiats/neural_network_s.F90
@@ -715,24 +715,10 @@ contains
       real, parameter :: tolerance = 1.E-06
 
       associate(n => lhs%nodes_)
-#ifndef __INTEL_COMPILER
         do concurrent(l = 1:ubound(n,1))
-            layer_eq(l) = all(abs(lhs%weights_(1:n(l),1:n(l-1),l) - rhs%weights_(1:n(l),1:n(l-1),l)) < tolerance) .and. &
-                          all(abs(lhs%biases_(1:n(l),l)           - rhs%biases_(1:n(l),l)) < tolerance)
+          layer_eq(l) = all(abs(lhs%weights_(1:n(l),1:n(l-1),l) - rhs%weights_(1:n(l),1:n(l-1),l)) < tolerance) .and. &
+                        all(abs(lhs%biases_(1:n(l),l)           - rhs%biases_(1:n(l),l)) < tolerance)
         end do
-#else
-        block
-          integer j, k
-          do l = 1, ubound(n,1)
-            do j = 1, n(l)
-              do k = 1, n(l-1)
-                layer_eq(l) = all(abs(lhs%weights_(j,k,l) - rhs%weights_(j,k,l)) < tolerance) .and. &
-                              all(abs(lhs%biases_(j,l)    - rhs%biases_(j,l)) < tolerance)
-              end do
-            end do
-          end do
-        end block
-#endif
       end associate
 
       lhs_eq_rhs = nodes_eq .and. all(layer_eq)
@@ -756,24 +742,10 @@ contains
       real, parameter :: tolerance = 1.D-12
 
       associate(n => lhs%nodes_)
-#ifndef __INTEL_COMPILER
         do concurrent(l = 1:ubound(n,1))
-            layer_eq(l) = all(abs(lhs%weights_(1:n(l),1:n(l-1),l) - rhs%weights_(1:n(l),1:n(l-1),l)) < tolerance) .and. &
-                          all(abs(lhs%biases_(1:n(l),l)           - rhs%biases_(1:n(l),l)) < tolerance)
+          layer_eq(l) = all(abs(lhs%weights_(1:n(l),1:n(l-1),l) - rhs%weights_(1:n(l),1:n(l-1),l)) < tolerance) .and. &
+                        all(abs(lhs%biases_(1:n(l),l)           - rhs%biases_(1:n(l),l)) < tolerance)
         end do
-#else
-        block
-          integer j, k
-          do l = 1, ubound(n,1)
-            do j = 1, n(l)
-              do k = 1, n(l-1)
-                layer_eq(l) = all(abs(lhs%weights_(j,k,l) - rhs%weights_(j,k,l)) < tolerance) .and. &
-                              all(abs(lhs%biases_(j,l)    - rhs%biases_(j,l)) < tolerance)
-              end do
-            end do
-          end do
-        end block
-#endif
       end associate
 
       lhs_eq_rhs = nodes_eq .and. all(layer_eq)


### PR DESCRIPTION
The 0.15.0 build does not currently work with ifx due to a few compiler bugs. These bugs will hopefully be fixed in an upcoming 2025 release of ifx. However, Fiats also has a few bugs that prevent compilation on ifx, which this PR addresses. See the commit messages for each individual commit for more details.