### PR TITLE
refac(example):simple learn-saturated-mixing-ratio

### DIFF
--- a/example/learn-saturated-mixing-ratio.F90
+++ b/example/learn-saturated-mixing-ratio.F90
@@ -2,7 +2,7 @@
 ! Terms of use are as specified in LICENSE.txt
 program train_saturated_mixture_ratio
   !! This program trains a neural network to learn the saturated mixing ratio function of ICAR.
-  use fiats_m, only : neural_network_t, trainable_network_t, mini_batch_t, tensor_t, input_output_pair_t, shuffle
+  use fiats_m, only : trainable_network_t, mini_batch_t, tensor_t, input_output_pair_t, shuffle
   use julienne_m, only : string_t, file_t, command_line_t, bin_t, csv
   use assert_m, only : assert, intrinsic_array_t
   use saturated_mixing_ratio_m, only : y, T, p
@@ -42,7 +42,7 @@ program train_saturated_mixture_ratio
 
     if (io_status == io_success) then
       print *,"Reading network from file " // network_file%string()
-      trainable_network = trainable_network_t(neural_network_t(file_t(network_file)))
+      trainable_network = trainable_network_t(file_t(network_file))
       close(network_unit)
     else
       close(network_unit)
@@ -154,11 +154,11 @@ contains
      write(unit=plot_file_unit, fmt=csv) nodes
   end subroutine
 
-  subroutine output(neural_network, file_name)
-    class(neural_network_t), intent(in) :: neural_network
+  subroutine output(trainable_network, file_name)
+    type(trainable_network_t), intent(in) :: trainable_network
     type(string_t), intent(in) :: file_name
     type(file_t) json_file
-    json_file = neural_network%to_json()
+    json_file = trainable_network%to_json()
     call json_file%write_lines(file_name)
   end subroutine
 
@@ -186,9 +186,9 @@ contains
       call random_number(b_harvest)
 
       associate(w => identity + perturbation_magnitude*(w_harvest-0.5)/0.5, b => perturbation_magnitude*(b_harvest-0.5)/0.5)
-        trainable_network = trainable_network_t( neural_network_t(nodes=n, weights=w, biases=b, &
+        trainable_network = trainable_network_t(nodes=n, weights=w, biases=b, &
           metadata=[string_t("Saturated Mixing Ratio"),string_t("Rouson"),string_t("20241013"),string_t("relu"),string_t("false")] &
-        ))
+        )
       end associate
     end associate
   end function

--- a/src/fiats/trainable_network_m.f90
+++ b/src/fiats/trainable_network_m.f90
@@ -27,6 +27,16 @@ module trainable_network_m
 
   interface trainable_network_t 
 
+    module function default_real_construct_from_components(metadata, weights, biases, nodes, input_map, output_map) &
+      result(trainable_network)
+      implicit none
+      type(string_t), intent(in) :: metadata(:)
+      real, intent(in) :: weights(:,:,:), biases(:,:)
+      integer, intent(in) :: nodes(0:)
+      type(tensor_map_t), intent(in), optional :: input_map, output_map
+      type(trainable_network_t) trainable_network
+    end function
+
     pure module function default_real_network(neural_network) result(trainable_network)
       implicit none
       type(neural_network_t), intent(in) :: neural_network

--- a/src/fiats/trainable_network_s.F90
+++ b/src/fiats/trainable_network_s.F90
@@ -6,6 +6,11 @@ submodule(trainable_network_m) trainable_network_s
 
 contains
 
+  module procedure default_real_construct_from_components
+    trainable_network%neural_network_t = neural_network_t(metadata, weights, biases, nodes, input_map, output_map)
+    trainable_network%workspace_ = workspace_t(trainable_network%neural_network_t)
+  end procedure
+
   module procedure default_real_network
     trainable_network%neural_network_t = neural_network
     trainable_network%workspace_ = workspace_t(neural_network)


### PR DESCRIPTION
This commit adds a `trainable_network_t` constructor that accepts the components derived types components directly rather than exposing the use of its `neural_network_t` parent as an intermediary.  This eliminates the need for the `neural_network_t` type in the `learn-saturated-mixing-ratio example` and thereby makes that example's use of Fiats entities a subset of the entities used by the similar but much more complicated demonstration application `train-cloud-microphysics`.  This change makes the example a useful proxy for the demonstration application when introducing new users to the demonstration application in the ISS conference paper.