### PR TITLE
chore(example): usage info specifies compiler

### DIFF
--- a/example/concurrent-inferences.f90
+++ b/example/concurrent-inferences.f90
@@ -28,7 +28,7 @@ program concurrent_inferences
       // '    --flag -O3 \'                      // new_line('') &
       // '    -- --network "<file-name>" \'      // new_line('') &
       // '    [--do-concurrent] [--openmp] [--elemental] [--double-precision] [--trials <integer>]' // new_line('') &
-      // ' where <> indicates user input and [] indicates an optional argument.'
+      // 'where <> indicates user input and [] indicates an optional argument.'
   end if
 
   inputs = random_inputs()

--- a/example/concurrent-inferences.f90
+++ b/example/concurrent-inferences.f90
@@ -20,12 +20,15 @@ program concurrent_inferences
   network_file_name = string_t(command_line%flag_value("--network"))
 
   if (len(network_file_name%string())==0) then
-    error stop new_line('') // new_line('') &
-      //  'Usage: ' // new_line('') &
-      // '  fpm run --example concurrent-inferences --profile release --flag "-fopenmp" \' // new_line('') &
-      // '    -- --network "<file-name>" \' //  new_line('') &
+    error stop                      new_line('') // new_line('') &
+      // 'Usage:'                                // new_line('') &
+      // '  fpm run \'                           // new_line('') &
+      // '    --example concurrent-inferences \' // new_line('') &
+      // '    --compiler flang-new \'            // new_line('') &
+      // '    --flag -O3 \'                      // new_line('') &
+      // '    -- --network "<file-name>" \'      // new_line('') &
       // '    [--do-concurrent] [--openmp] [--elemental] [--double-precision] [--trials <integer>]' // new_line('') &
-      // ' where <> indicates user input and [] indicates an optional argument.' // new_line('')
+      // ' where <> indicates user input and [] indicates an optional argument.'
   end if
 
   inputs = random_inputs()


### PR DESCRIPTION
With this commit, the concurrent-inferences example prints the following usage information if the program doesn't receive the required command-line arguments:
```
Usage:
  fpm run \
    --example concurrent-inferences \
    --compiler flang-new \
    --flag -O3 \
    -- --network "<file-name>" \
    [--do-concurrent] [--openmp] [--elemental] [--double-precision] [--trials <integer>]
  where <> indicates user input and [] indicates an optional argument.
```